### PR TITLE
feat: 인증 API 연동 및 httpOnly 쿠키 기반 토큰 관리 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ storybook-static
 
 # private agent playbook (do not commit)
 .agent/
+
+# Claude Orchestrator
+.orchestrator.json
+*_LOG.md
+PLAN.md

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,15 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async rewrites() {
+    const backendUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+    return [
+      {
+        source: '/api/v1/:path*',
+        destination: `${backendUrl}/api/v1/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { setTokenCookies } from '@/lib/api/cookies';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+
+  const backendRes = await fetch(`${BASE_URL}/api/v1/member/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  const json = await backendRes.json();
+
+  if (!backendRes.ok || !json.success) {
+    return NextResponse.json(json, { status: backendRes.status });
+  }
+
+  // TODO: 백엔드 응답 구조 확인 필요 — json.data.{ accessToken, refreshToken } 가정
+  const { accessToken, refreshToken } = json.data;
+  const response = NextResponse.json({
+    status: json.status,
+    success: true,
+    message: json.message,
+    data: null,
+  });
+
+  setTokenCookies(response, accessToken, refreshToken);
+  return response;
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { clearTokenCookies } from '@/lib/api/cookies';
+
+export async function POST() {
+  const response = NextResponse.json({
+    status: 200,
+    success: true,
+    message: '로그아웃 완료',
+    data: null,
+  });
+
+  clearTokenCookies(response);
+  return response;
+}

--- a/src/app/api/auth/token-reissue/route.ts
+++ b/src/app/api/auth/token-reissue/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  setTokenCookies,
+  clearTokenCookies,
+  REFRESH_TOKEN_KEY,
+} from '@/lib/api/cookies';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+
+export async function POST(request: NextRequest) {
+  const refreshToken = request.cookies.get(REFRESH_TOKEN_KEY)?.value;
+
+  if (!refreshToken) {
+    return NextResponse.json(
+      { status: 401, success: false, message: '리프레시 토큰 없음', data: null },
+      { status: 401 },
+    );
+  }
+
+  const backendRes = await fetch(`${BASE_URL}/api/v1/member/token-reissue`, {
+    method: 'POST',
+    headers: { 'X-Refresh-Token': refreshToken },
+  });
+
+  const json = await backendRes.json();
+
+  if (!backendRes.ok || !json.success) {
+    const response = NextResponse.json(json, { status: backendRes.status });
+    clearTokenCookies(response);
+    return response;
+  }
+
+  // TODO: 백엔드 응답 구조 확인 필요 — json.data.{ accessToken, refreshToken } 가정
+  const { accessToken: newAccess, refreshToken: newRefresh } = json.data;
+  const response = NextResponse.json({
+    status: json.status,
+    success: true,
+    message: json.message,
+    data: null,
+  });
+
+  setTokenCookies(response, newAccess, newRefresh);
+  return response;
+}

--- a/src/features/auth/api/index.ts
+++ b/src/features/auth/api/index.ts
@@ -1,0 +1,34 @@
+import { api } from '@/lib/api';
+import type { ApiResponse } from '@/lib/api';
+import type { LoginRequest, LoginResponse, SignupRequest } from '@/features/auth/types';
+
+/**
+ * 로그인 — Next.js Route Handler 프록시 경유
+ * Route Handler가 쿠키를 set한 뒤 data: null을 반환
+ */
+export function login(body: LoginRequest): Promise<ApiResponse<null>> {
+  return api.post<null>('/api/auth/login', body, { auth: false });
+}
+
+/**
+ * 회원가입 — 백엔드 직접 호출
+ * TODO: 백엔드 회원가입 응답 data 타입 확인 필요
+ */
+export function signup(body: SignupRequest): Promise<ApiResponse<null>> {
+  return api.post<null>('/api/v1/member/signup', body, { auth: false });
+}
+
+/**
+ * 토큰 재발급 — Next.js Route Handler 프록시 경유
+ * TODO: 백엔드 토큰 재발급 응답 구조 확인 필요 (LoginResponse 가정)
+ */
+export function tokenReissue(): Promise<ApiResponse<LoginResponse>> {
+  return api.post<LoginResponse>('/api/auth/token-reissue', undefined, { auth: false });
+}
+
+/**
+ * 회원 탈퇴 — 인증 필요 (auth: true 기본값)
+ */
+export function withdraw(): Promise<ApiResponse<null>> {
+  return api.delete<null>('/api/v1/member/withdraw');
+}

--- a/src/features/auth/components/LoginForm/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm/LoginForm.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import * as React from "react";
 
 import { Button } from "@/components/ui/atoms/Button/Button";
+import { ApiError } from "@/lib/api";
 
+import { login } from "@/features/auth/api";
 import { UnderlineField } from "@/features/auth/components/_shared/UnderlineField";
 
 /* eslint-disable @next/next/no-img-element */
@@ -20,9 +23,11 @@ function validatePassword(pw: string) {
 }
 
 export function LoginForm() {
+  const router = useRouter();
   const [id, setId] = React.useState("");
   const [password, setPassword] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
   const [touched, setTouched] = React.useState<{ id: boolean; password: boolean }>({
     id: false,
     password: false,
@@ -43,11 +48,17 @@ export function LoginForm() {
     setTouched({ id: true, password: true });
     if (!canSubmit) return;
 
+    setError(null);
     setSubmitting(true);
     try {
-      // TODO: API 연동 전까지는 UI/기능만 구현
-      await new Promise((r) => setTimeout(r, 600));
-      alert("로그인 기능은 준비 중입니다.");
+      await login({ email: id, password });
+      router.replace('/');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('로그인 중 오류가 발생했습니다.');
+      }
     } finally {
       setSubmitting(false);
     }
@@ -84,6 +95,9 @@ export function LoginForm() {
       </div>
 
       <div className="flex w-full flex-col items-center gap-6">
+        {error && (
+          <p className="w-full text-center text-sm text-coral-400">{error}</p>
+        )}
         <Button type="submit" className="w-full" disabled={!canSubmit}>
           {submitting ? "로그인 중..." : "로그인하기"}
         </Button>

--- a/src/features/auth/components/SignupForm/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm/SignupForm.tsx
@@ -1,9 +1,13 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import * as React from "react";
 
 import { Button } from "@/components/ui/atoms/Button/Button";
+import { ApiError } from "@/lib/api";
+
+import { signup } from "@/features/auth/api";
 import { UnderlineField } from "@/features/auth/components/_shared/UnderlineField";
 
 function isValidEmail(email: string) {
@@ -21,6 +25,7 @@ function validatePassword(pw: string) {
 }
 
 export function SignupForm() {
+  const router = useRouter();
   const [phone, setPhone] = React.useState("");
   const [name, setName] = React.useState("");
   const [birth, setBirth] = React.useState("");
@@ -29,6 +34,7 @@ export function SignupForm() {
   const [passwordConfirm, setPasswordConfirm] = React.useState("");
 
   const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
   const [touched, setTouched] = React.useState<Record<string, boolean>>({});
 
   const phoneErrorId = React.useId();
@@ -83,11 +89,17 @@ export function SignupForm() {
     });
     if (!canSubmit) return;
 
+    setError(null);
     setSubmitting(true);
     try {
-      // TODO: API 연동 전까지는 UI/기능만 구현
-      await new Promise((r) => setTimeout(r, 600));
-      alert("회원가입 기능은 준비 중입니다.");
+      await signup({ email, password, name });
+      router.push('/login');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('회원가입 중 오류가 발생했습니다.');
+      }
     } finally {
       setSubmitting(false);
     }
@@ -313,6 +325,9 @@ export function SignupForm() {
           </div>
         </div>
 
+        {error && (
+          <p className="w-full text-center text-sm text-coral-400">{error}</p>
+        )}
         <div className="inline-flex items-center justify-center gap-8">
           <Button
             type="submit"

--- a/src/features/auth/types/index.ts
+++ b/src/features/auth/types/index.ts
@@ -1,0 +1,18 @@
+// 로그인
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+// TODO: 백엔드 응답 구조 확인 필요 — accessToken/refreshToken 가정
+export interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+// 회원가입
+export interface SignupRequest {
+  email: string;
+  password: string;
+  name: string;
+}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,105 @@
+// 공통 응답 타입
+export interface ApiResponse<T> {
+  status: number;
+  success: boolean;
+  message: string;
+  data: T;
+}
+
+// HTTP 메서드별 옵션
+type RequestOptions = Omit<RequestInit, 'method' | 'body'> & {
+  params?: Record<string, string>;
+  /** true면 인터셉터(JWT 주입, 401 재시도) 적용. 기본값 true */
+  auth?: boolean;
+};
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+
+/**
+ * fetch 래퍼 — baseURL 결합, JSON 직렬화, 공통 헤더 적용
+ * auth 옵션이 true(기본)이면 fetchWithAuth를 사용하여 JWT 주입·401 재시도 처리
+ *
+ * 브라우저: 상대경로로 요청 → Next.js rewrites/Route Handler 경유 (CORS 우회)
+ * 서버(SSR): BASE_URL을 붙여 백엔드 직접 호출
+ */
+async function request<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  options: RequestOptions = {},
+): Promise<ApiResponse<T>> {
+  const { params, headers: customHeaders, auth = true, ...restInit } = options;
+
+  // 브라우저에서는 상대경로(same-origin), 서버에서는 BASE_URL 사용
+  const origin = typeof window !== 'undefined' ? window.location.origin : BASE_URL;
+  const url = new URL(path, origin);
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      url.searchParams.set(key, value);
+    });
+  }
+
+  const headers = new Headers(customHeaders);
+  if (!headers.has('Content-Type') && body !== undefined) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  // 클라이언트에서 auth가 true면 인터셉터 적용 (쿠키 자동 전송 + 401 재시도)
+  // 서버(SSR)에서 인증 API가 필요하면 interceptors.server.ts를 직접 사용
+  let fetchFn = fetch;
+  if (auth && typeof window !== 'undefined') {
+    const { fetchWithAuth } = await import('./interceptors');
+    fetchFn = fetchWithAuth;
+  }
+
+  const response = await fetchFn(url.toString(), {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    ...restInit,
+  });
+
+  // 204 No Content 등 빈 응답 처리
+  if (response.status === 204) {
+    return { status: 204, success: true, message: '', data: null as T };
+  }
+
+  const json: ApiResponse<T> = await response.json();
+
+  if (!response.ok) {
+    throw new ApiError(json.message, response.status, json);
+  }
+
+  return json;
+}
+
+// API 에러 클래스
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public response: ApiResponse<unknown>,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+// 메서드별 단축 함수
+export const api = {
+  get<T>(path: string, options?: RequestOptions) {
+    return request<T>('GET', path, undefined, options);
+  },
+  post<T>(path: string, body?: unknown, options?: RequestOptions) {
+    return request<T>('POST', path, body, options);
+  },
+  put<T>(path: string, body?: unknown, options?: RequestOptions) {
+    return request<T>('PUT', path, body, options);
+  },
+  patch<T>(path: string, body?: unknown, options?: RequestOptions) {
+    return request<T>('PATCH', path, body, options);
+  },
+  delete<T>(path: string, options?: RequestOptions) {
+    return request<T>('DELETE', path, undefined, options);
+  },
+} as const;

--- a/src/lib/api/cookies.ts
+++ b/src/lib/api/cookies.ts
@@ -1,0 +1,54 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+const ACCESS_TOKEN_KEY = 'access_token';
+const REFRESH_TOKEN_KEY = 'refresh_token';
+
+const ACCESS_TOKEN_MAX_AGE = 30 * 60; // 30분
+const REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60; // 7일
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax' as const,
+  path: '/',
+};
+
+/** NextResponse에 토큰 쿠키를 세팅한다 (Route Handler 전용) */
+export function setTokenCookies(
+  response: NextResponse,
+  accessToken: string,
+  refreshToken: string,
+) {
+  response.cookies.set(ACCESS_TOKEN_KEY, accessToken, {
+    ...COOKIE_OPTIONS,
+    maxAge: ACCESS_TOKEN_MAX_AGE,
+  });
+  response.cookies.set(REFRESH_TOKEN_KEY, refreshToken, {
+    ...COOKIE_OPTIONS,
+    maxAge: REFRESH_TOKEN_MAX_AGE,
+  });
+}
+
+/** NextResponse에서 토큰 쿠키를 삭제한다 (Route Handler 전용) */
+export function clearTokenCookies(response: NextResponse) {
+  response.cookies.set(ACCESS_TOKEN_KEY, '', {
+    ...COOKIE_OPTIONS,
+    maxAge: 0,
+  });
+  response.cookies.set(REFRESH_TOKEN_KEY, '', {
+    ...COOKIE_OPTIONS,
+    maxAge: 0,
+  });
+}
+
+/** 서버 컴포넌트 / Route Handler에서 쿠키 읽기 (next/headers) */
+export async function getTokensFromCookies() {
+  const cookieStore = await cookies();
+  return {
+    accessToken: cookieStore.get(ACCESS_TOKEN_KEY)?.value ?? null,
+    refreshToken: cookieStore.get(REFRESH_TOKEN_KEY)?.value ?? null,
+  };
+}
+
+export { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY };

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,5 @@
+export { api, ApiError } from './client';
+export type { ApiResponse } from './client';
+// 서버 전용 (클라이언트 번들 오염 방지를 위해 직접 import):
+//   fetchWithAuthServer → '@/lib/api/interceptors.server'
+//   getTokensFromCookies → '@/lib/api/cookies'

--- a/src/lib/api/interceptors.server.ts
+++ b/src/lib/api/interceptors.server.ts
@@ -1,0 +1,24 @@
+/**
+ * 서버용 fetch 인터셉터 — next/headers 쿠키를 읽어 Authorization 헤더 주입
+ *
+ * 서버 컴포넌트에서만 사용. 클라이언트 번들에 포함되지 않도록 별도 파일로 분리.
+ */
+
+import { getTokensFromCookies } from './cookies';
+
+export async function fetchWithAuthServer(
+  input: string | URL | Request,
+  init?: RequestInit,
+): Promise<Response> {
+  const { accessToken, refreshToken } = await getTokensFromCookies();
+
+  const headers = new Headers(init?.headers);
+  if (accessToken) {
+    headers.set('Authorization', `Bearer ${accessToken}`);
+  }
+  if (refreshToken) {
+    headers.set('X-Refresh-Token', refreshToken);
+  }
+
+  return fetch(input, { ...init, headers });
+}

--- a/src/lib/api/interceptors.ts
+++ b/src/lib/api/interceptors.ts
@@ -1,0 +1,52 @@
+/**
+ * 클라이언트용 fetch 인터셉터 — httpOnly 쿠키 기반 인증
+ *
+ * credentials: 'include'로 쿠키 자동 전송,
+ * 401 시 /api/auth/token-reissue Route Handler를 통해 재발급 후 재시도
+ */
+
+// 토큰 재발급 중복 요청 방지
+let refreshPromise: Promise<boolean> | null = null;
+
+async function reissueToken(): Promise<boolean> {
+  try {
+    const response = await fetch('/api/auth/token-reissue', {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!response.ok) return false;
+
+    const json = await response.json();
+    return json.success;
+  } catch {
+    return false;
+  }
+}
+
+/** 클라이언트용 인터셉터 — 쿠키 자동 전송 + 401 재발급 재시도 */
+export async function fetchWithAuth(
+  input: string | URL | Request,
+  init?: RequestInit,
+): Promise<Response> {
+  let response = await fetch(input, {
+    ...init,
+    credentials: 'include',
+  });
+
+  // 401 시 토큰 재발급 후 1회 재시도
+  if (response.status === 401) {
+    if (!refreshPromise) {
+      refreshPromise = reissueToken().finally(() => {
+        refreshPromise = null;
+      });
+    }
+
+    const refreshed = await refreshPromise;
+
+    if (refreshed) {
+      response = await fetch(input, { ...init, credentials: 'include' });
+    }
+  }
+
+  return response;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈                                                              
                                                        
  #10                                                                           
                                                         
  ## 📝작업 내용                                                                
                                                        
  ### 공통 API 인프라 구축 (`src/lib/api/`)                                     
  - fetch 래퍼 (`client.ts`) — `ApiResponse<T>` 타입, `ApiError` 클래스,        
  GET/POST/PUT/PATCH/DELETE 단축 함수                                           
  - 클라이언트 인터셉터 (`interceptors.ts`) — credentials: include 자동 적용,
  401 시 토큰 재발급 후 1회 재시도                                              
  - 서버 인터셉터 (`interceptors.server.ts`) — next/headers 쿠키 읽어
  Authorization 헤더 주입                                                       
  - 쿠키 유틸 (`cookies.ts`) — httpOnly 쿠키 기반 토큰 set/get/clear (access
  30분, refresh 7일)                                                            
                                                        
  ### Route Handler 인증 프록시 (`src/app/api/auth/`)                           
  - `login/route.ts` — 백엔드 로그인 호출 후 토큰을 httpOnly 쿠키로 세팅
  - `logout/route.ts` — 토큰 쿠키 클리어                                        
  - `token-reissue/route.ts` — 리프레시 토큰으로 재발급 프록시, 실패 시 쿠키
  클리어                                                                        
                                                        
  ### Auth feature API 레이어                                                   
  - 타입 정의 (`features/auth/types/`) — LoginRequest, LoginResponse,
  SignupRequest                                                                 
  - API 함수 (`features/auth/api/`) — login, signup, tokenReissue, withdraw
                                                                                
  ### 폼 컴포넌트 API 연동                              
  - `LoginForm.tsx` — login() 호출, 에러 메시지 표시, 성공 시 `/`로 리다이렉트
  - `SignupForm.tsx` — signup() 호출, 에러 메시지 표시, 성공 시 `/login`으로    
  이동                                                                          
                                                                                
  ### 설정                                                                      
  - `next.config.ts` — `/api/v1/*` 백엔드 rewrites 추가 
  - `.gitignore` — orchestrator 관련 파일 무시 추가                             
                                                         
  ## 💬리뷰 요구사항(선택)                                                      
                                                        
  - 클라이언트 인터셉터의 401 재시도 로직(`interceptors.ts`)이 동시 요청 시 정상
   동작하는지 검토 부탁드립니다    
  - 백엔드 응답 구조를 `json.data.{ accessToken, refreshToken }`으로 가정했는데,
   실제 구조와 맞는지 확인 필요합니다